### PR TITLE
grepl

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -29,9 +29,11 @@ library(htmltools)
 
 ```{r læsfiler, echo = F}
 json_files <- list.files(path = "data/", full.names = T)
-
-json_files <- json_files[json_files != "data/template.json"]
 json_files
+
+
+json_files <- json_files[!grepl("template.json", json_files)]
+
 ```
 
 ```{r hent_data, echo = F}


### PR DESCRIPTION
Lokalt fjernes template ved at lede efter data/template.json. Men på github er stien data//template.json. grepl skulle gerne komme uden om dette.